### PR TITLE
reuse port in WSServer and send last frame

### DIFF
--- a/rts/backend/ws_server.h
+++ b/rts/backend/ws_server.h
@@ -26,12 +26,21 @@ typedef Server::message_ptr message_ptr;
 // A simple websocket server with only one client
 class WSServer {
   public:
+    ~WSServer()
+    {
+      server_.close(*hdl_.get(), websocketpp::close::status::normal, "game's over");
+      server_.stop_listening();
+      th_.join();
+    }
+
     WSServer(int port, std::function<void(const std::string&)> callback):
       callback_{callback}
     {
       try {
         // Set logging settings -- no log
         server_.clear_access_channels(websocketpp::log::alevel::all);
+
+        server_.set_reuse_addr(true);
 
         // Initialize Asio
         server_.init_asio();

--- a/rts/engine/ai.h
+++ b/rts/engine/ai.h
@@ -46,6 +46,7 @@ protected:
 public:
     AI() : _player_id(INVALID), _receiver(nullptr), _frame_skip(1) { }
     AI(PlayerId player_id, int frameskip, CmdReceiver *receiver) : _player_id(player_id), _receiver(receiver), _frame_skip(frameskip) { }
+    virtual ~AI() {}
     PlayerId GetId() const { return _player_id; }
 
     void SetId(PlayerId id) {

--- a/rts/engine/game.cc
+++ b/rts/engine/game.cc
@@ -383,6 +383,9 @@ PlayerId RTSGame::MainLoop(const std::atomic_bool *done) {
           for (const auto &bot : _bots) {
               bot->Act(_env, true);
           }
+          if (_spectator != nullptr) {
+            _spectator->Act(_env);
+          }
           break;
       }
 


### PR DESCRIPTION
Set reuse addr to be true for websocket server. Also add cleanup code
for the connection. Without that, a quick restart of visualization
will fail due to error "asio.system:98 (Address already in use)" in
linux.

Also send the last frame to the spectator.