### PR TITLE
Fix a simple bug in ex_elfpy.py

### DIFF
--- a/ex_elfpy.py
+++ b/ex_elfpy.py
@@ -1,5 +1,5 @@
-from elf_python import GCWrapper, Simulator
 import torch
+from elf_python import GCWrapper, Simulator
 import random
 import tqdm
 


### PR DESCRIPTION
I found at ubuntu16.04, python3.5 and cuda8,the example crashed with this errpor.

`*** Error in python3': free(): invalid pointer: 0x00007f98524c1b80 ***
======= Backtrace: =========
/lib/x86_64-linux-gnu/libc.so.6(+0x777e5)[0x7f986429c7e5]
/lib/x86_64-linux-gnu/libc.so.6(+0x8037a)[0x7f98642a537a]
/lib/x86_64-linux-gnu/libc.so.6(cfree+0x4c)[0x7f98642a953c]...` 

As I find it [here](https://github.com/pytorch/pytorch/issues/2507),it seemed to be a pytorch bug.The solution is to import torch first of the any other statement.After I do this,it works well.
Thanks.