### PR TITLE
make game.py work with Py2.7

### DIFF
--- a/atari/game.py
+++ b/atari/game.py
@@ -9,39 +9,43 @@
 # -*- coding: utf-8 -*-
 # File: game.py
 
-from datetime import datetime
-from collections import Counter
 import argparse
-from time import sleep
-import os
 import atari_game as atari
-import torch
-
+from collections import Counter
+from datetime import datetime
+import os
+import random
 import sys
-sys.path.append('../')
 
+# elf related import
+sys.path.append('../')
 from elf import GCWrapper, ContextArgs
 from rlpytorch import ArgsProvider
+
 
 class Loader:
     def __init__(self):
         self.context_args = ContextArgs()
 
         self.args = ArgsProvider(
-            call_from = self,
-            define_args = [
+            call_from=self,
+            define_args=[
                 ("frame_skip", 4),
                 ("hist_len", 4),
                 ("rom_file", "pong.bin"),
                 ("actor_only", dict(action="store_true")),
                 ("reward_clip", 1),
                 ("rom_dir", os.path.dirname(__file__)),
-                ("additional_labels", dict(type=str, default=None, help="Add additional labels in the batch. E.g., id,seq,last_terminal")),
+                ("additional_labels", dict(
+                    type=str,
+                    default=None,
+                    help="Add additional labels in the batch."
+                    " E.g., id,seq,last_terminal",
+                )),
                 ("gpu", dict(type=int, default=None)),
             ],
-            more_args = ["batchsize", "T", "env_eval_only"],
-            child_providers = [ self.context_args.args ]
-        )
+            more_args=["batchsize", "T", "env_eval_only"],
+            child_providers=[self.context_args.args])
 
     def initialize(self):
         args = self.args
@@ -63,31 +67,36 @@ class Loader:
         print("Num Actions: ", params["num_action"])
 
         desc = {}
-        # For actor model, No reward needed, we only want to get input and return distribution of actions.
+        # For actor model, No reward needed, we only want to get input
+        # and return distribution of actions.
         # sampled action and and value will be filled from the reply.
 
         desc["actor"] = dict(
             batchsize=args.batchsize,
             input=dict(T=1, keys=set(["s", "last_r", "last_terminal"])),
-            reply=dict(T=1, keys=set(["rv", "pi", "V", "a"]))
-        )
+            reply=dict(T=1, keys=set(["rv", "pi", "V", "a"])))
 
         if not args.actor_only:
             # For training: group 1
-            # We want input, action (filled by actor models), value (filled by actor
-            # models) and reward.
+            # We want input, action (filled by actor models), value
+            # (filled by actor models) and reward.
             desc["train"] = dict(
                 batchsize=args.batchsize,
-                input=dict(T=args.T, keys=set(["rv", "id", "pi", "s", "a", "last_r", "V", "seq", "last_terminal"])),
-                reply=None
-            )
+                input=dict(
+                    T=args.T,
+                    keys=set([
+                        "rv", "id", "pi", "s", "a", "last_r", "V", "seq",
+                        "last_terminal"
+                    ])),
+                reply=None)
 
         if args.additional_labels is not None:
             extra = args.additional_labels.split(",")
             for _, v in desc.items():
                 v["input"]["keys"].update(extra)
 
-        # Initialize shared memory (between Python and C++) based on the specification defined by desc.
+        # Initialize shared memory (between Python and C++)
+        # based on the specification defined by desc.
         params["num_group"] = 1 if args.actor_only else 2
         params["action_batchsize"] = desc["actor"]["batchsize"]
         if not args.actor_only:
@@ -95,15 +104,15 @@ class Loader:
         params["hist_len"] = args.hist_len
         params["T"] = args.T
 
-        return GCWrapper(GC, co, desc, gpu=args.gpu, use_numpy=False, params=params)
+        return GCWrapper(
+            GC, co, desc, gpu=args.gpu, use_numpy=False, params=params)
 
-cmd_line = "--num_games 64 --batchsize 16 --hist_len 1 --frame_skip 4 --actor_only"
+
+cmd_line = \
+    "--num_games 64 --batchsize 16 --hist_len 1 --frame_skip 4 --actor_only"
 
 nIter = 5000
 elapsed_wait_only = 0
-
-import pickle
-import random
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
@@ -119,23 +128,30 @@ if __name__ == '__main__':
 
     actor_count = 0
     train_count = 0
+
     def actor(batch):
         global actor_count, GC
         actor_count += 1
-        batchsize = sel["s"].size(1)
-        actions = [ random.randint(0, GC.params["num_action"]-1) for i in range(batchsize) ]
+        batchsize = batch["s"].size(1)
+        actions = [
+            random.randint(0, GC.params["num_action"] - 1)
+            for i in range(batchsize)
+        ]
         reply = dict(a=actions)
-
         '''
-        data = sel.to_numpy()
+        data = batch.to_numpy()
         data.update(reply)
-        pickle.dump(data, open("tmp-actor%d.bin" % actor_count, "wb"), protocol=2)
+        pickle.dump(
+            data, open("tmp-actor%d.bin" % actor_count, "wb"), protocol=2)
         '''
         return reply
 
     def train(batch):
         global train_count
-        # pickle.dump(sel.to_numpy(), open("tmp-train%d.bin" % train_count, "wb"), protocol=2)
+        # pickle.dump(
+        #     sel.to_numpy(),
+        #     open("tmp-train%d.bin" % train_count, "wb"),
+        #     protocol=2, )
         train_count += 1
 
     GC.reg_callback("actor", actor)
@@ -147,16 +163,17 @@ if __name__ == '__main__':
     GC.Start()
 
     import tqdm
-    for k in tqdm.trange(nIter):
+    for _ in tqdm.trange(nIter):
         b = datetime.now()
-        # print("Before wait")
+        # Before wait
         GC.Run()
-        # print("wake up from wait")
+        # wake up from wait
         elapsed_wait_only += (datetime.now() - b).total_seconds() * 1000
 
     print(reward_dist)
     elapsed = (datetime.now() - before).total_seconds() * 1000
-    print("elapsed = %.4lf ms, elapsed_wait_only = %.4lf" % (elapsed, elapsed_wait_only))
+    print("elapsed = %.4lf ms, elapsed_wait_only = %.4lf" %
+          (elapsed, elapsed_wait_only))
     GC.PrintSummary()
     GC.Stop()
 
@@ -169,5 +186,9 @@ if __name__ == '__main__':
     fps_loop = 1000 / per_frame_loop_n_cpu * args.frame_skip
     fps_wait = 1000 / per_frame_wait_n_cpu * args.frame_skip
 
-    print("Time[Loop]: %.6lf ms / loop, %.6lf ms / frame_loop_n_cpu, %.2f FPS" % (per_loop, per_frame_loop_n_cpu, fps_loop))
-    print("Time[Wait]: %.6lf ms / wait, %.6lf ms / frame_wait_n_cpu, %.2f FPS" % (per_wait, per_frame_wait_n_cpu, fps_wait))
+    print(
+        "Time[Loop]: %.6lf ms / loop, %.6lf ms / frame_loop_n_cpu, %.2f FPS" %
+        (per_loop, per_frame_loop_n_cpu, fps_loop))
+    print(
+        "Time[Wait]: %.6lf ms / wait, %.6lf ms / frame_wait_n_cpu, %.2f FPS" %
+        (per_wait, per_frame_wait_n_cpu, fps_wait))

--- a/elf/utils_elf.py
+++ b/elf/utils_elf.py
@@ -32,6 +32,7 @@ class Batch:
         ''' Initialize `Batch` class. Pass in a dict and wrap it into ``self.batch``'''
         self.batch = kwargs
 
+    @staticmethod
     def _request(GC, group_id, key, T):
         info = GC.GetTensorSpec(group_id, key, T)
         # print("Key = \"%s\"" % str(key))
@@ -43,6 +44,7 @@ class Batch:
                 raise ValueError("key[%s] or last_key[%s] is not specified!" % (key, last_key))
         return info
 
+    @staticmethod
     def _alloc(info, use_gpu=True, use_numpy=True):
         if not use_numpy:
             v = Batch.torch_types[info.type](*info.sz)
@@ -59,6 +61,7 @@ class Batch:
 
         return v, info
 
+    @staticmethod
     def load(GC, input_reply, desc, group_id, use_gpu=True, use_numpy=False):
         '''load Batch from the specifications
 
@@ -237,7 +240,7 @@ class GCWrapper:
             print("Deal with connector. key = %s, hist_len = %d, player_name = %s" % (key, gstat.hist_len, gstat.player_name))
 
             gpu2gid.append(list())
-            for i in range(num_recv_thread):
+            for i in range(int(num_recv_thread)):
                 group_id = GC.AddCollectors(batchsize, len(gpu2gid) - 1, gstat)
 
                 inputs.append(Batch.load(GC, "input", input, group_id, use_gpu=use_gpu, use_numpy=use_numpy))
@@ -335,4 +338,3 @@ class GCWrapper:
     def PrintSummary(self):
         '''Print summary'''
         self.GC.PrintSummary()
-

--- a/rlpytorch/args_provider.py
+++ b/rlpytorch/args_provider.py
@@ -64,6 +64,7 @@ class Args:
     def __contains__(self, key):
         return hasattr(self, key)
 
+
 class ArgsProvider:
     def __init__(self, define_args=[], more_args=[], on_get_args=None, call_from=None, child_providers=[], child_transforms=None):
         '''Define arguments to be loaded from the command line. Example usage
@@ -152,6 +153,7 @@ class ArgsProvider:
         if self._on_get_args is not None:
             self._on_get_args(args)
 
+    @staticmethod
     def _GetProvider(x):
         if isinstance(x, ArgsProvider):
             return x
@@ -160,6 +162,7 @@ class ArgsProvider:
         else:
             raise ValueError("ArgsProvider not found! " + str(x))
 
+    @staticmethod
     def _SendArgsToParser(parser, all_args):
         for group_name, define_args in all_args:
             group = parser.add_argument_group(group_name)
@@ -170,17 +173,20 @@ class ArgsProvider:
                     # If there is issues with argument name. just plot a warning.
                     print("Warning: argument %s/%s cannot be added. Skipped." % (group_name, key))
 
+    @staticmethod
     def _ApplyDefaults(global_defaults, args_list):
         for _, define_args in args_list:
             for k, v in define_args:
                 if k in global_defaults:
                     v["default"] = global_defaults[k]
 
+    @staticmethod
     def _ApplyOverrides(global_overrides, args):
         for k, v in global_overrides.items():
             if k in args:
                 args[k] = v
 
+    @staticmethod
     def Load(parser, args_providers, cmd_line=sys.argv[1:], global_defaults=dict(), global_overrides=dict()):
         '''Load args from ``cmd_line``
 

--- a/rlpytorch/runner/__init__.py
+++ b/rlpytorch/runner/__init__.py
@@ -1,3 +1,3 @@
 from .single_process import SingleProcessRun
-from .multi_process import MultiProcessRun
+# from .multi_process import MultiProcessRun
 from .eval_iters import EvalIters

--- a/rlpytorch/trainer/trainer.py
+++ b/rlpytorch/trainer/trainer.py
@@ -15,8 +15,8 @@ from .timer import RLTimer
 from .utils import ModelSaver, MultiCounter
 from datetime import datetime
 
-import torch.multiprocessing as _mp
-mp = _mp.get_context('spawn')
+# import torch.multiprocessing as _mp
+# mp = _mp.get_context('spawn')
 
 class Evaluator:
     def __init__(self, name="eval", stats=True, verbose=False, actor_name="actor"):


### PR DESCRIPTION
Several changes:
- add staticmethod mark to some functions
- remove unused multi process import 
- game.py can now work with python 2.7
- fix lint complaint in atari/game.py


output here:
```
========== Args ============
instance: frame_skip=4,hist_len=4,rom_file="/home/wyiming/local/roms/pong.bin",actor_only=False,reward_clip=1,rom_dir="",additional_labels=None,gpu=None
instance: num_games=1024,batchsize=128,game_multi=None,T=6,eval=False,wait_per_group=False,verbose_comm=False,verbose_collector=False
========== End of Args ============
Warning: key = env_eval_only cannot be found from either args or environment!
A.L.E: Arcade Learning Environment (version 0.5.1)
[Powered by Stella]
Use -help for help screen.
Warning: couldn't load settings file: ./ale.cfg
Game console created:
  ROM file:  /home/wyiming/local/roms/pong.bin
  Cart Name: Video Olympics (1978) (Atari)
  Cart MD5:  60e0ea3cbe0913d39803477945e9e5ec
  Display Format:  AUTO-DETECT ==> NTSC
  ROM Size:        2048
  Bankswitch Type: AUTO-DETECT ==> 2K


WARNING: Possibly unsupported ROM: mismatched MD5.
Cartridge_MD5: 60e0ea3cbe0913d39803477945e9e5ec
Cartridge_name: Video Olympics (1978) (Atari)

Running ROM file...
Random seed is 92442963
Action set: 0 1 3 4 11 12
('Version: ', u'0960273ea7ccc1959af28aea3ba8ddbdd7043544_staged')
('Num Actions: ', 6L)
#recv_thread = 4
Deal with connector. key = train, hist_len = 6, player_name =
Deal with connector. key = actor, hist_len = 1, player_name =
 94%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████        | 4682/5000 [00:40<00:02, 115.06it/s
```