### PR TITLE
Fix fallthrough

### DIFF
--- a/rts/game_MC/trainable_ai.cc
+++ b/rts/game_MC/trainable_ai.cc
@@ -104,6 +104,7 @@ bool TrainedAI::handle_response(const State &s, const Data &data, RTSMCAction *a
                 std::for_each(unit_cmds.begin(), unit_cmds.end(), [&](CmdInput &ci) { ci.ApplyEnv(env); });
                 a->SetUnitCmds(unit_cmds);
             }
+            break;
 
             /*
         case ACTION_REGIONAL:


### PR DESCRIPTION
GCC 7 enables `-Wimplicit-fallthrough` which caught the missing `break`.