### PR TITLE
Change device_id -> device

### DIFF
--- a/rlpytorch/model_interface.py
+++ b/rlpytorch/model_interface.py
@@ -96,7 +96,7 @@ class ModelInterface:
         self.models[key] = model.clone() if copy else model
         if cuda:
             if gpu_id is not None:
-                self.models[key].cuda(device_id=gpu_id)
+                self.models[key].cuda(device=gpu_id)
             else:
                 self.models[key].cuda()
 

--- a/rlpytorch/model_loader.py
+++ b/rlpytorch/model_loader.py
@@ -92,7 +92,7 @@ class ModelLoader:
                     sys.exit(1)
 
         if args.gpu is not None and args.gpu >= 0:
-            model.cuda(device_id=args.gpu)
+            model.cuda(device=args.gpu)
 
         return model
 


### PR DESCRIPTION
Per this change in PyTorch: https://github.com/pytorch/pytorch/pull/2872 (post v0.2.0)

Without the patch, I see the following error:
```
Traceback (most recent call last):
  File "train.py", line 24, in <module>
    model = env["model_loaders"][0].load_model(GC.params)
  File "/home/cyang/src/ELF/rlpytorch/model_loader.py", line 95, in load_model
    model.cuda(device_id=args.gpu)
TypeError: cuda() got an unexpected keyword argument 'device_id'
```