### PR TITLE
add support for boolean params

### DIFF
--- a/rlpytorch/model_loader.py
+++ b/rlpytorch/model_loader.py
@@ -96,6 +96,9 @@ class ModelLoader:
 
         return model
 
+def str2bool(v):
+  return v.lower() in ("yes", "true", "t", "1")
+
 def load_env(envs, num_models=None, overrides=dict(), defaults=dict(), **kwargs):
     ''' Load envs. envs will be specified as environment variables, more specifically, ``game``, ``model_file`` and ``model`` are required.
 
@@ -132,5 +135,6 @@ def load_env(envs, num_models=None, overrides=dict(), defaults=dict(), **kwargs)
     env.update(kwargs)
 
     parser = argparse.ArgumentParser()
+    parser.register('type', 'bool', str2bool)
     all_args = ArgsProvider.Load(parser, env, global_defaults=defaults, global_overrides=overrides)
     return  env, all_args


### PR DESCRIPTION
This simple PR add supports for boolean parameters in the argument parser.

This enables to use the following kind of argument declaration 
`("bool_flag", dict(type='bool', default=False , help="Example boolean flag"))`

Then the corresponding command line would look like:
`python my_script.py --bool_flag 1`