### PR TITLE
Update elf to support pytorch 0.4

### DIFF
--- a/elf/utils_elf.py
+++ b/elf/utils_elf.py
@@ -152,7 +152,7 @@ class Batch:
                 elif isinstance(v, (int, float)):
                     bk.fill_(v)
                 else:
-                    bk[:] = v
+                    bk[:] = v.view_as(bk[:])
 
             else:
                 raise ValueError("Batch[%s]: \"%s\" in reply is missing in batch specification" % (batch_key, k))

--- a/rlpytorch/methods/actor_critic.py
+++ b/rlpytorch/methods/actor_critic.py
@@ -72,5 +72,5 @@ class ActorCritic:
             err = add_err(err, policy_err)
             err = add_err(err, self.value_matcher.feed({ value_node: V, "target" : R}, stats))
 
-        stats["cost"].feed(err.data[0] / (T - 1))
+        stats["cost"].feed(err.item() / (T - 1))
         err.backward()

--- a/rlpytorch/methods/discounted_reward.py
+++ b/rlpytorch/methods/discounted_reward.py
@@ -24,7 +24,7 @@ class DiscountedReward:
     def setR(self, R, stats):
         ''' Set rewards and feed to stats'''
         self.R = R
-        stats["init_reward"].feed(R.mean())
+        stats["init_reward"].feed(R.mean().item())
 
     def feed(self, batch, stats):
         '''
@@ -49,7 +49,7 @@ class DiscountedReward:
             if terminal:
                 self.R[i] = r[i]
 
-        stats["reward"].feed(r.mean())
-        stats["acc_reward"].feed(self.R.mean())
+        stats["reward"].feed(r.mean().item())
+        stats["acc_reward"].feed(self.R.mean().item())
 
         return self.R

--- a/rlpytorch/methods/policy_gradient.py
+++ b/rlpytorch/methods/policy_gradient.py
@@ -149,14 +149,14 @@ class PolicyGradient:
             entropy_err = add_err(entropy_err, errs["entropy_err"])
             log_pi_s.append(errs["logpi"])
 
-            stats["nll_" + pi_node].feed(errs["policy_err"].data[0])
-            stats["entropy_" + pi_node].feed(errs["entropy_err"].data[0])
+            stats["nll_" + pi_node].feed(errs["policy_err"].item())
+            stats["entropy_" + pi_node].feed(errs["entropy_err"].item())
 
         for log_pi in log_pi_s:
             self._reg_backward(log_pi, Variable(pg_weights))
 
         if len(args.policy_action_nodes) > 1:
-            stats["total_nll"].feed(policy_err.data[0])
-            stats["total_entropy"].feed(entropy_err.data[0])
+            stats["total_nll"].feed(policy_err.item())
+            stats["total_entropy"].feed(entropy_err.item())
 
         return policy_err + entropy_err * args.entropy_ratio

--- a/rlpytorch/methods/value_matcher.py
+++ b/rlpytorch/methods/value_matcher.py
@@ -68,7 +68,7 @@ class ValueMatcher:
         V = batch[self.value_node]
         value_err = self.value_loss(V, Variable(batch["target"]))
         self._reg_backward(V)
-        stats["predicted_" + self.value_node].feed(V.data[0])
-        stats[self.value_node + "_err"].feed(value_err.data[0])
+        stats["predicted_" + self.value_node].feed(V[0].item())
+        stats[self.value_node + "_err"].feed(value_err.item())
 
         return value_err

--- a/rlpytorch/model_base.py
+++ b/rlpytorch/model_base.py
@@ -55,7 +55,7 @@ class Model(nn.Module):
             Variable for x
         '''
         if not isinstance(x, Variable):
-            return Variable(x, volatile=self.volatile)
+            return Variable(x)
         else:
             return x
 

--- a/rlpytorch/model_interface.py
+++ b/rlpytorch/model_interface.py
@@ -95,7 +95,7 @@ class ModelInterface:
         self.models[key] = model.clone() if copy else model
         if cuda:
             if gpu_id is not None:
-                self.models[key].cuda(device_id=gpu_id)
+                self.models[key].cuda(device=gpu_id)
             else:
                 self.models[key].cuda()
 

--- a/rlpytorch/model_loader.py
+++ b/rlpytorch/model_loader.py
@@ -92,7 +92,7 @@ class ModelLoader:
                     sys.exit(1)
 
         if args.gpu is not None and args.gpu >= 0:
-            model.cuda(device_id=args.gpu)
+            model.cuda(device=args.gpu)
 
         return model
 

--- a/rlpytorch/stats/stats.py
+++ b/rlpytorch/stats/stats.py
@@ -77,9 +77,9 @@ class EvalCount:
         last_r = batch["last_r"][hist_idx]
 
         for batch_idx, (id, last_terminal) in enumerate(zip(ids, last_terminals)):
-            self.feed(id, last_r[batch_idx])
-            if last_terminal:
-                self.terminal(id)
+            self.feed(id.item(), last_r[batch_idx].item())
+            if last_terminal.item() == 1:
+                self.terminal(id.item())
 
 class RewardCount(EvalCount):
     ''' Class to accumulate rewards achieved'''

--- a/rlpytorch/trainer/trainer.py
+++ b/rlpytorch/trainer/trainer.py
@@ -6,6 +6,7 @@
 
 import os
 import sys
+import torch
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'elf'))
 import utils_elf
 from ..args_provider import ArgsProvider
@@ -69,9 +70,8 @@ class Evaluator:
 
         # actor model.
         m = self.mi[self.actor_name]
-        m.set_volatile(True)
-        state_curr = m.forward(batch.hist(0))
-        m.set_volatile(False)
+        with torch.no_grad():
+            state_curr = m.forward(batch.hist(0))
 
         if self.sampler is not None:
             reply_msg = self.sampler.sample(state_curr)


### PR DESCRIPTION
This PR updates the code base to be somewhat compatible with the new version of Pytorch.
Note that the new Pytorch version includes fixes in important things like the multinomial distribution (which is used in ELF). Hence it can lead to a different behaviour.

A summary of the changes:
- Use .item() where appropriate. I may have missed some places, since I only tested this PR on Atari
- Remove volatile and use torch.no_grad instead
- Some stricter reshaping to cope with finickier dimension checks

Unfortunately, merging this PR means that ELF no longer works on 0.3 and earlier.