### PR TITLE
Fix evaluation script

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -44,6 +44,7 @@ if __name__ == '__main__':
     GC.Start()
 
     evaluator.episode_start(0)
+    model.train(False)
 
     for n in eval_iters.iters():
         GC.Run()


### PR DESCRIPTION
This PR ensures the model is evaluation mode at evaluation time.

Failure to do so cause incorrect behavior, especially if the model contains dropout or BatchNorm layers.