### PR TITLE
fix async for usage with python 3.7

### DIFF
--- a/elf/utils_elf.py
+++ b/elf/utils_elf.py
@@ -188,13 +188,13 @@ class Batch:
         else:
             return self[key][s]
 
-    def transfer_cpu2gpu(self, batch_gpu, async=True):
+    def transfer_cpu2gpu(self, batch_gpu, asynch=True):
         ''' transfer batch data to gpu '''
         # For each time step
         for k, v in self.batch.items():
-            batch_gpu[k].copy_(v, async=async)
+            batch_gpu[k].copy_(v, asynch=asynch)
 
-    def transfer_cpu2cpu(self, batch_dst, async=True):
+    def transfer_cpu2cpu(self, batch_dst, asynch=True):
         ''' transfer batch data to cpu '''
 
         # For each time step

--- a/elf/utils_elf.py
+++ b/elf/utils_elf.py
@@ -188,13 +188,13 @@ class Batch:
         else:
             return self[key][s]
 
-    def transfer_cpu2gpu(self, batch_gpu, asynch=True):
+    def transfer_cpu2gpu(self, batch_gpu, =True):
         ''' transfer batch data to gpu '''
         # For each time step
         for k, v in self.batch.items():
-            batch_gpu[k].copy_(v, asynch=asynch)
+            batch_gpu[k].copy_(v)
 
-    def transfer_cpu2cpu(self, batch_dst, asynch=True):
+    def transfer_cpu2cpu(self, batch_dst):
         ''' transfer batch data to cpu '''
 
         # For each time step

--- a/elf/utils_elf.py
+++ b/elf/utils_elf.py
@@ -188,7 +188,7 @@ class Batch:
         else:
             return self[key][s]
 
-    def transfer_cpu2gpu(self, batch_gpu, =True):
+    def transfer_cpu2gpu(self, batch_gpu):
         ''' transfer batch data to gpu '''
         # For each time step
         for k, v in self.batch.items():

--- a/elf_python/memory_receiver.py
+++ b/elf_python/memory_receiver.py
@@ -75,19 +75,19 @@ def _cpu2gpu(batch_cpu, batch_gpu, allow_incomplete_batch=False):
             if isinstance(batch_cpu_t[k], (torch.FloatTensor, torch.LongTensor)):
                 if allow_incomplete_batch:
                     if len(batch_cpu_t[k].size()) == 1:
-                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize].cuda(asynch=True)
+                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize].cuda()
                     else:
-                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize, :].cuda(asynch=True)
+                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize, :].cuda()
                 else:
                     if isinstance(batch_cpu_t[k], torch.FloatTensor):
                         if k not in batch_gpu_t:
                             batch_gpu_t[k] = torch.cuda.FloatTensor(batch_cpu_t[k].size())
-                        batch_gpu_t[k].copy_(batch_cpu_t[k], asynch=True)
+                        batch_gpu_t[k].copy_(batch_cpu_t[k])
 
                     elif isinstance(batch_cpu_t[k], torch.LongTensor):
                         if k not in batch_gpu_t:
                             batch_gpu_t[k] = torch.cuda.LongTensor(batch_cpu_t[k].size())
-                        batch_gpu_t[k].copy_(batch_cpu_t[k], asynch=True)
+                        batch_gpu_t[k].copy_(batch_cpu_t[k])
             else:
                 batch_gpu_t[k] = batch_cpu_t[k]
 

--- a/elf_python/memory_receiver.py
+++ b/elf_python/memory_receiver.py
@@ -75,19 +75,19 @@ def _cpu2gpu(batch_cpu, batch_gpu, allow_incomplete_batch=False):
             if isinstance(batch_cpu_t[k], (torch.FloatTensor, torch.LongTensor)):
                 if allow_incomplete_batch:
                     if len(batch_cpu_t[k].size()) == 1:
-                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize].cuda(async=True)
+                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize].cuda(asynch=True)
                     else:
-                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize, :].cuda(async=True)
+                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize, :].cuda(asynch=True)
                 else:
                     if isinstance(batch_cpu_t[k], torch.FloatTensor):
                         if k not in batch_gpu_t:
                             batch_gpu_t[k] = torch.cuda.FloatTensor(batch_cpu_t[k].size())
-                        batch_gpu_t[k].copy_(batch_cpu_t[k], async=True)
+                        batch_gpu_t[k].copy_(batch_cpu_t[k], asynch=True)
 
                     elif isinstance(batch_cpu_t[k], torch.LongTensor):
                         if k not in batch_gpu_t:
                             batch_gpu_t[k] = torch.cuda.LongTensor(batch_cpu_t[k].size())
-                        batch_gpu_t[k].copy_(batch_cpu_t[k], async=True)
+                        batch_gpu_t[k].copy_(batch_cpu_t[k], asynch=True)
             else:
                 batch_gpu_t[k] = batch_cpu_t[k]
 

--- a/rlpytorch/runner/parameter_server.py
+++ b/rlpytorch/runner/parameter_server.py
@@ -215,7 +215,7 @@ class SharedData:
 
         while True:
             self.cvs_recv[i].wait()
-            utils_elf.transfer_cpu2gpu(batch, batch_gpu, async=True)
+            utils_elf.transfer_cpu2gpu(batch, batch_gpu, asynch=True)
             self.cvs_send[i].notify()
             self.cb_remote_batch_process(context, batch_gpu)
 

--- a/rlpytorch/runner/parameter_server.py
+++ b/rlpytorch/runner/parameter_server.py
@@ -215,7 +215,7 @@ class SharedData:
 
         while True:
             self.cvs_recv[i].wait()
-            utils_elf.transfer_cpu2gpu(batch, batch_gpu, asynch=True)
+            utils_elf.transfer_cpu2gpu(batch, batch_gpu)
             self.cvs_send[i].notify()
             self.cb_remote_batch_process(context, batch_gpu)
 


### PR DESCRIPTION
In Python 3.7, `async` is a reserved word, so I changed it (there were only a few occurrences) to `asynch`. This has only affected `.py` files.