### PR TITLE
Remove mentions to `async`reserved keyword for usage with Python 3.7

### DIFF
--- a/elf/utils_elf.py
+++ b/elf/utils_elf.py
@@ -188,13 +188,13 @@ class Batch:
         else:
             return self[key][s]
 
-    def transfer_cpu2gpu(self, batch_gpu, async=True):
+    def transfer_cpu2gpu(self, batch_gpu, asynch=True):
         ''' transfer batch data to gpu '''
         # For each time step
         for k, v in self.batch.items():
-            batch_gpu[k].copy_(v, async=async)
+            batch_gpu[k].copy_(v, asynch=asynch)
 
-    def transfer_cpu2cpu(self, batch_dst, async=True):
+    def transfer_cpu2cpu(self, batch_dst, asynch=True):
         ''' transfer batch data to cpu '''
 
         # For each time step

--- a/elf/utils_elf.py
+++ b/elf/utils_elf.py
@@ -188,13 +188,13 @@ class Batch:
         else:
             return self[key][s]
 
-    def transfer_cpu2gpu(self, batch_gpu, asynch=True):
+    def transfer_cpu2gpu(self, batch_gpu):
         ''' transfer batch data to gpu '''
         # For each time step
         for k, v in self.batch.items():
-            batch_gpu[k].copy_(v, asynch=asynch)
+            batch_gpu[k].copy_(v)
 
-    def transfer_cpu2cpu(self, batch_dst, asynch=True):
+    def transfer_cpu2cpu(self, batch_dst):
         ''' transfer batch data to cpu '''
 
         # For each time step

--- a/elf_python/memory_receiver.py
+++ b/elf_python/memory_receiver.py
@@ -75,19 +75,19 @@ def _cpu2gpu(batch_cpu, batch_gpu, allow_incomplete_batch=False):
             if isinstance(batch_cpu_t[k], (torch.FloatTensor, torch.LongTensor)):
                 if allow_incomplete_batch:
                     if len(batch_cpu_t[k].size()) == 1:
-                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize].cuda(asynch=True)
+                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize].cuda()
                     else:
-                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize, :].cuda(asynch=True)
+                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize, :].cuda()
                 else:
                     if isinstance(batch_cpu_t[k], torch.FloatTensor):
                         if k not in batch_gpu_t:
                             batch_gpu_t[k] = torch.cuda.FloatTensor(batch_cpu_t[k].size())
-                        batch_gpu_t[k].copy_(batch_cpu_t[k], asynch=True)
+                        batch_gpu_t[k].copy_(batch_cpu_t[k])
 
                     elif isinstance(batch_cpu_t[k], torch.LongTensor):
                         if k not in batch_gpu_t:
                             batch_gpu_t[k] = torch.cuda.LongTensor(batch_cpu_t[k].size())
-                        batch_gpu_t[k].copy_(batch_cpu_t[k], asynch=True)
+                        batch_gpu_t[k].copy_(batch_cpu_t[k])
             else:
                 batch_gpu_t[k] = batch_cpu_t[k]
 

--- a/elf_python/memory_receiver.py
+++ b/elf_python/memory_receiver.py
@@ -75,19 +75,19 @@ def _cpu2gpu(batch_cpu, batch_gpu, allow_incomplete_batch=False):
             if isinstance(batch_cpu_t[k], (torch.FloatTensor, torch.LongTensor)):
                 if allow_incomplete_batch:
                     if len(batch_cpu_t[k].size()) == 1:
-                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize].cuda(async=True)
+                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize].cuda(asynch=True)
                     else:
-                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize, :].cuda(async=True)
+                        batch_gpu_t[k] = batch_cpu_t[k][:batchsize, :].cuda(asynch=True)
                 else:
                     if isinstance(batch_cpu_t[k], torch.FloatTensor):
                         if k not in batch_gpu_t:
                             batch_gpu_t[k] = torch.cuda.FloatTensor(batch_cpu_t[k].size())
-                        batch_gpu_t[k].copy_(batch_cpu_t[k], async=True)
+                        batch_gpu_t[k].copy_(batch_cpu_t[k], asynch=True)
 
                     elif isinstance(batch_cpu_t[k], torch.LongTensor):
                         if k not in batch_gpu_t:
                             batch_gpu_t[k] = torch.cuda.LongTensor(batch_cpu_t[k].size())
-                        batch_gpu_t[k].copy_(batch_cpu_t[k], async=True)
+                        batch_gpu_t[k].copy_(batch_cpu_t[k], asynch=True)
             else:
                 batch_gpu_t[k] = batch_cpu_t[k]
 

--- a/rlpytorch/runner/parameter_server.py
+++ b/rlpytorch/runner/parameter_server.py
@@ -215,7 +215,7 @@ class SharedData:
 
         while True:
             self.cvs_recv[i].wait()
-            utils_elf.transfer_cpu2gpu(batch, batch_gpu, async=True)
+            utils_elf.transfer_cpu2gpu(batch, batch_gpu, asynch=True)
             self.cvs_send[i].notify()
             self.cb_remote_batch_process(context, batch_gpu)
 

--- a/rlpytorch/runner/parameter_server.py
+++ b/rlpytorch/runner/parameter_server.py
@@ -215,7 +215,7 @@ class SharedData:
 
         while True:
             self.cvs_recv[i].wait()
-            utils_elf.transfer_cpu2gpu(batch, batch_gpu, asynch=True)
+            utils_elf.transfer_cpu2gpu(batch, batch_gpu)
             self.cvs_send[i].notify()
             self.cb_remote_batch_process(context, batch_gpu)
 


### PR DESCRIPTION
In this PR, I've deleted all mentions to the `async` keyword in the master branch of ELF to resume compatibility of the repository with Python 3.7

ELF uses `async` as a name for variables and function parameters. In Python 3.7, `async` has become a reserved word. The word is only used as argument to the `copy_` and `cuda` methods, which are methods from the `pytorch.Tensor` object. But these methods don't use the value of the `async` argument for anything.

By removing mentions to the now-reserved keyword, no change in the behavior of the package is expected. I've tested training a model using `./train_minirts.sh` on Python 3.7 with both CPU and GPU and everything worked. I believe this fixes #124 and #127.

I created a new PR because I used my master branch as the head repository in #134, which was a bad idea on my side.