### PR TITLE
Fix CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ cache:
 language: cpp
 python:
   - 3.6
-  - 3.7
 compiler:
   - gcc
   - clang
@@ -39,5 +38,5 @@ install:
 script:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
   - (mkdir rts/build_MC && cd rts/build_MC && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_MC && make)
-  - (mkdir rts/build_CF && cd rts/build_CF && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_CF && make)
-  - (mkdir rts/build_TD && cd rts/build_TD && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_TD && make)
+#  - (mkdir rts/build_CF && cd rts/build_CF && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_CF && make)
+#  - (mkdir rts/build_TD && cd rts/build_TD && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_TD && make)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 language: cpp
 python:
   - 3.6
+  - 3.7
 compiler:
   - gcc
   - clang
@@ -37,6 +38,6 @@ install:
 
 script:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
-  - (mkdir rts/build_MC && cd rts/build_MC && cmake .. -DGAME_DIR=../game_MC && make)
-  - (mkdir rts/build_CF && cd rts/build_CF && cmake .. -DGAME_DIR=../game_CF && make)
-  - (mkdir rts/build_TD && cd rts/build_TD && cmake .. -DGAME_DIR=../game_TD && make)
+  - (mkdir rts/build_MC && cd rts/build_MC && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_MC && make)
+  - (mkdir rts/build_CF && cd rts/build_CF && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_CF && make)
+  - (mkdir rts/build_TD && cd rts/build_TD && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_TD && make)

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ cache:
 language: cpp
 python:
   - 3.6
+  - 3.7
 compiler:
   - gcc
   - clang
@@ -37,6 +38,12 @@ install:
 
 script:
   - if [ "$CXX" = "g++" ]; then export CXX="g++-4.9" CC="gcc-4.9"; fi
-  - (mkdir rts/build_MC && cd rts/build_MC && cmake .. -DGAME_DIR=../game_MC && make)
-  - (mkdir rts/build_CF && cd rts/build_CF && cmake .. -DGAME_DIR=../game_CF && make)
-  - (mkdir rts/build_TD && cd rts/build_TD && cmake .. -DGAME_DIR=../game_TD && make)
+  - (mkdir rts/build_MC && cd rts/build_MC && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_MC && make)
+  - (mkdir rts/build_CF && cd rts/build_CF && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_CF && make)
+  - (mkdir rts/build_TD && cd rts/build_TD && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python -DGAME_DIR=../game_TD && make)
+  - (mkdir rts/build_MC && cd rts/build_MC && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python3 -DGAME_DIR=../game_MC && make)
+  - (mkdir rts/build_CF && cd rts/build_CF && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python3 -DGAME_DIR=../game_CF && make)
+  - (mkdir rts/build_TD && cd rts/build_TD && cmake .. -DPYTHON_EXECUTABLE=/opt/pyenv/shims/python3 -DGAME_DIR=../game_TD && make)
+  - (mkdir rts/build_MC && cd rts/build_MC && cmake .. -DPYTHON_EXECUTABLE=/usr/bin/python -DGAME_DIR=../game_MC && make)
+  - (mkdir rts/build_CF && cd rts/build_CF && cmake .. -DPYTHON_EXECUTABLE=/usr/bin/python -DGAME_DIR=../game_CF && make)
+  - (mkdir rts/build_TD && cd rts/build_TD && cmake .. -DPYTHON_EXECUTABLE=/usr/bin/python -DGAME_DIR=../game_TD && make)


### PR DESCRIPTION
This PR aims to fix the CI build of the repo on Travis.

I have listed my findings on #136. Basically, Tower Defense (TD) and Capture the Flag (CF) are not compiling since October 2018, due to a commit that made breaking changes in the elf base library in order to add features to the main RTS game (MC).

It looks to me as though TD and CF are abandoned, so I've fixed the build of the MC module (which was also broken for a different reason) on `.travis.yml` and created this PR to discuss what to do with TD and CF.